### PR TITLE
fix: remove UUID-based notification trigger functions

### DIFF
--- a/lib/notifications/README.md
+++ b/lib/notifications/README.md
@@ -22,22 +22,13 @@ Triggers a single notification by its database ID.
 **Returns:** `TriggerResult` object containing:
 - `success`: Boolean indicating if the trigger was successful
 - `notificationId`: The notification ID
-- `transactionId`: The notification's transaction ID (UUID)
-- `novuTransactionId`: The Novu transaction ID (if successful)
+- `novuTransactionId`: The Novu transaction ID returned by Novu (if successful)
 - `status`: Final notification status
 - `error`: Error message (if failed)
 - `details`: Additional details including recipient results
 - `notification`: The notification data
 - `workflow`: The workflow configuration
 
-### `triggerNotificationByUuid(transactionId: string)`
-
-Triggers a notification by its transaction ID (UUID).
-
-**Parameters:**
-- `transactionId`: The UUID of the notification
-
-**Returns:** `TriggerResult` object
 
 ### `triggerNotificationsByIds(notificationIds: number[])`
 
@@ -48,15 +39,6 @@ Triggers multiple notifications by their database IDs.
 
 **Returns:** Array of `TriggerResult` objects
 
-### `batchTriggerNotifications(transactionIds: string[], batchSize?: number)`
-
-Batch triggers multiple notifications by UUIDs with concurrency control.
-
-**Parameters:**
-- `transactionIds`: Array of notification UUIDs
-- `batchSize`: Number of concurrent operations (default: 10)
-
-**Returns:** Array of `TriggerResult` objects
 
 ### `triggerPendingNotifications(limit?: number)`
 
@@ -123,13 +105,13 @@ All functions include comprehensive error handling:
 
 ```typescript
 // app/api/trigger/route.ts
-import { triggerNotificationByUuid } from '@/lib/notifications';
+import { triggerNotificationById } from '@/lib/notifications';
 
 export async function POST(request: Request) {
-  const { transactionId } = await request.json();
+  const { notificationId } = await request.json();
   
-  const result = await triggerNotificationByUuid(
-    transactionId
+  const result = await triggerNotificationById(
+    notificationId
   );
   
   return Response.json(result);
@@ -140,13 +122,13 @@ export async function POST(request: Request) {
 
 ```typescript
 // temporal/activities/notification.ts
-import { batchTriggerNotifications } from '@/lib/notifications';
+import { triggerNotificationsByIds } from '@/lib/notifications';
 
 export async function processNotificationBatch(
-  transactionIds: string[]
+  notificationIds: number[]
 ) {
-  // Process with concurrency limit of 5
-  return await batchTriggerNotifications(transactionIds, 5);
+  // Process multiple notifications
+  return await triggerNotificationsByIds(notificationIds);
 }
 ```
 

--- a/lib/notifications/index.ts
+++ b/lib/notifications/index.ts
@@ -1,9 +1,6 @@
 export {
   triggerNotificationById,
-  triggerNotificationByUuid,
-  triggerNotificationByTransactionId,
   triggerNotificationsByIds,
-  batchTriggerNotifications,
   triggerPendingNotifications,
   triggerNotificationByCriteria,
   type TriggerResult,

--- a/scripts/test-unpublished-notification.ts
+++ b/scripts/test-unpublished-notification.ts
@@ -6,7 +6,7 @@
 
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
-import { triggerNotificationByUuid } from '../lib/notifications';
+import { triggerNotificationById } from '../lib/notifications';
 import type { Database } from '../lib/supabase/database.types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -77,8 +77,8 @@ async function testUnpublishedNotification() {
 
     // Step 3: Try to trigger the unpublished notification
     console.log('\n🔔 Attempting to trigger unpublished notification...');
-    const result = await triggerNotificationByUuid(
-      notification!.transaction_id!
+    const result = await triggerNotificationById(
+      notification!.id
     );
 
     if (result.success) {

--- a/scripts/test-yogo-email.ts
+++ b/scripts/test-yogo-email.ts
@@ -8,7 +8,7 @@
 
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
-import { triggerNotificationByUuid } from '../lib/notifications';
+import { triggerNotificationById } from '../lib/notifications';
 import type { Database } from '../lib/supabase/database.types';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -111,8 +111,8 @@ async function testYogoEmail() {
 
     // Step 3: Trigger using temporal function
     console.log('\n🔔 Triggering yogo-email workflow via temporal function...');
-    const result = await triggerNotificationByUuid(
-      notification!.transaction_id!  // Use transaction_id, not id
+    const result = await triggerNotificationById(
+      notification!.id
     );
 
     if (result.success) {


### PR DESCRIPTION
## Summary
- Remove incorrect UUID-based notification trigger functions
- Fix misunderstanding about transactionId usage
- Update all related documentation and test scripts

## Context
The `transactionId` is actually a result returned from Novu after triggering a notification, not something that exists in the database beforehand. The previous implementation incorrectly assumed we could lookup notifications by a `transaction_id` that didn't exist yet.

## Changes
- **Removed functions:**
  - `triggerNotificationByUuid()` 
  - `triggerNotificationByTransactionId` (alias)
  - `batchTriggerNotifications()` (used UUID arrays)

- **Updated documentation:**
  - `docs/temporal-novu-integration.md` - Now uses `triggerNotificationById`
  - `lib/notifications/README.md` - Removed UUID-based function references

- **Fixed test scripts:**
  - `scripts/test-unpublished-notification.ts` - Uses notification ID
  - `scripts/test-yogo-email.ts` - Uses notification ID

## Test plan
- [x] Run linter - passes with no errors
- [x] Run `pnpm exec tsx scripts/test-yogo-email.ts` to verify notifications still trigger correctly
- [x] Run `pnpm exec tsx scripts/test-unpublished-notification.ts` to verify draft notifications are rejected
- [x] Verify Temporal workflows can trigger notifications by ID

🤖 Generated with [Claude Code](https://claude.ai/code)