### PR TITLE
feat: integrate template rendering into notification triggers

### DIFF
--- a/__tests__/integration/NotificationTemplateRendering.integration.test.ts
+++ b/__tests__/integration/NotificationTemplateRendering.integration.test.ts
@@ -1,0 +1,552 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Database } from '@/lib/supabase/database.types';
+import { triggerNotificationById } from '@/lib/notifications/trigger';
+import { getTemplateRenderer } from '@/app/services/template/TemplateRenderer';
+import { Novu } from '@novu/api';
+
+// Mock Novu to prevent actual API calls
+jest.mock('@novu/api');
+
+describe('Notification Template Rendering Integration', () => {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
+  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+  const novuSecretKey = process.env.NOVU_SECRET_KEY || '';
+
+  // Validate that we have real credentials
+  beforeAll(() => {
+    if (!supabaseUrl || !supabaseServiceKey || !supabaseUrl.includes('supabase.co') || supabaseServiceKey.length <= 50) {
+      throw new Error('Real Supabase credentials required. Set NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY environment variables.');
+    }
+    if (!novuSecretKey || novuSecretKey.length <= 20) {
+      throw new Error('Real Novu credentials required. Set NOVU_SECRET_KEY environment variable.');
+    }
+  });
+
+  let supabase: ReturnType<typeof createClient<Database>>;
+  let testEnterpriseId: string;
+  let testWorkflowId: number;
+  let testTemplateId: number;
+  let mockNovuTrigger: jest.Mock;
+
+  beforeEach(() => {
+    supabase = createClient<Database>(supabaseUrl, supabaseServiceKey, {
+      auth: { persistSession: false }
+    });
+
+    // Set up mock Novu trigger
+    mockNovuTrigger = jest.fn().mockResolvedValue({
+      result: { transactionId: 'mock-transaction-123' }
+    });
+    (Novu as jest.MockedClass<typeof Novu>).mockImplementation(() => ({
+      trigger: mockNovuTrigger
+    } as any));
+
+    // Clear template cache before each test
+    const templateRenderer = getTemplateRenderer();
+    templateRenderer.clearCache();
+  });
+
+  afterEach(async () => {
+    // Clean up test data
+    if (testEnterpriseId) {
+      await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .delete()
+        .eq('enterprise_id', testEnterpriseId);
+
+      await supabase
+        .schema('notify')
+        .from('ent_notification_template')
+        .delete()
+        .eq('enterprise_id', testEnterpriseId);
+
+      await supabase
+        .schema('notify')
+        .from('ent_notification_workflow')
+        .delete()
+        .eq('enterprise_id', testEnterpriseId);
+    }
+  });
+
+  describe('Template Rendering in Notification Overrides', () => {
+    beforeEach(async () => {
+      // Create test enterprise ID
+      testEnterpriseId = `test-enterprise-${Date.now()}`;
+
+      // Create a test workflow
+      const { data: workflow, error: workflowError } = await supabase
+        .schema('notify')
+        .from('ent_notification_workflow')
+        .insert({
+          name: 'Test Template Workflow',
+          workflow_key: `test-workflow-${Date.now()}`,
+          workflow_type: 'DYNAMIC',
+          default_channels: ['EMAIL', 'IN_APP'],
+          description: 'Test workflow for template rendering',
+          enterprise_id: testEnterpriseId
+        })
+        .select()
+        .single();
+
+      if (workflowError || !workflow) {
+        throw new Error(`Failed to create test workflow: ${workflowError?.message}`);
+      }
+      testWorkflowId = workflow.id;
+
+      // Create test templates
+      const { data: template, error: templateError } = await supabase
+        .schema('notify')
+        .from('ent_notification_template')
+        .insert({
+          name: 'Footer Template',
+          template_key: 'footer_template',
+          channel_type: 'EMAIL',
+          body_template: 'Copyright © {{year}} {{company}}. All rights reserved.',
+          publish_status: 'PUBLISH',
+          deactivated: false,
+          enterprise_id: testEnterpriseId
+        })
+        .select()
+        .single();
+
+      if (templateError || !template) {
+        throw new Error(`Failed to create test template: ${templateError?.message}`);
+      }
+      testTemplateId = template.id;
+    });
+
+    it('should render simple variable interpolation in notification overrides', async () => {
+      // Create notification with template syntax in overrides
+      const { data: notification, error } = await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .insert({
+          name: 'Test Notification with Templates',
+          payload: {
+            userName: 'John Doe',
+            buildingName: 'Tower A',
+            temperature: 25.5
+          },
+          recipients: ['test-user-123'],
+          notification_workflow_id: testWorkflowId,
+          enterprise_id: testEnterpriseId,
+          notification_status: 'PENDING',
+          publish_status: 'PUBLISH',
+          overrides: {
+            email: {
+              subject: 'Alert for {{userName}}',
+              body: 'Building {{buildingName}} temperature is {{temperature}}°C'
+            },
+            inApp: {
+              content: 'Quick alert: {{buildingName}} needs attention!'
+            }
+          }
+        })
+        .select()
+        .single();
+
+      if (error || !notification) {
+        throw new Error(`Failed to create test notification: ${error?.message}`);
+      }
+
+      // Trigger the notification
+      const result = await triggerNotificationById(notification.id);
+
+      // Verify the result
+      expect(result.success).toBe(true);
+      expect(result.notificationId).toBe(notification.id);
+      expect(mockNovuTrigger).toHaveBeenCalledTimes(1);
+
+      // Verify that templates were rendered in the overrides
+      const [triggerCall] = mockNovuTrigger.mock.calls;
+      expect(triggerCall[0].overrides.email.subject).toBe('Alert for John Doe');
+      expect(triggerCall[0].overrides.email.body).toBe('Building Tower A temperature is 25.5°C');
+      expect(triggerCall[0].overrides.inApp.content).toBe('Quick alert: Tower A needs attention!');
+    });
+
+    it('should render nested object access in templates', async () => {
+      const { data: notification, error } = await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .insert({
+          name: 'Test Nested Template',
+          payload: {
+            user: {
+              profile: {
+                firstName: 'Jane',
+                lastName: 'Smith'
+              },
+              preferences: {
+                language: 'en-US'
+              }
+            },
+            alert: {
+              severity: 'HIGH',
+              location: {
+                building: 'Building B',
+                floor: 3
+              }
+            }
+          },
+          recipients: ['test-user-456'],
+          notification_workflow_id: testWorkflowId,
+          enterprise_id: testEnterpriseId,
+          notification_status: 'PENDING',
+          publish_status: 'PUBLISH',
+          overrides: {
+            email: {
+              subject: '{{alert.severity}} Alert - {{alert.location.building}}',
+              body: 'Dear {{user.profile.firstName}} {{user.profile.lastName}}, alert on floor {{alert.location.floor}}'
+            }
+          }
+        })
+        .select()
+        .single();
+
+      if (error || !notification) {
+        throw new Error(`Failed to create test notification: ${error?.message}`);
+      }
+
+      const result = await triggerNotificationById(notification.id);
+
+      expect(result.success).toBe(true);
+      const [triggerCall] = mockNovuTrigger.mock.calls;
+      expect(triggerCall[0].overrides.email.subject).toBe('HIGH Alert - Building B');
+      expect(triggerCall[0].overrides.email.body).toBe('Dear Jane Smith, alert on floor 3');
+    });
+
+    it('should render array access in templates', async () => {
+      const { data: notification, error } = await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .insert({
+          name: 'Test Array Template',
+          payload: {
+            devices: [
+              { id: 'dev-001', status: 'offline' },
+              { id: 'dev-002', status: 'online' }
+            ],
+            alerts: ['Temperature spike', 'Door left open', 'Motion detected']
+          },
+          recipients: ['test-user-789'],
+          notification_workflow_id: testWorkflowId,
+          enterprise_id: testEnterpriseId,
+          notification_status: 'PENDING',
+          publish_status: 'PUBLISH',
+          overrides: {
+            sms: {
+              content: 'Device {{devices[0].id}} is {{devices[0].status}}. Primary alert: {{alerts[0]}}'
+            }
+          }
+        })
+        .select()
+        .single();
+
+      if (error || !notification) {
+        throw new Error(`Failed to create test notification: ${error?.message}`);
+      }
+
+      const result = await triggerNotificationById(notification.id);
+
+      expect(result.success).toBe(true);
+      const [triggerCall] = mockNovuTrigger.mock.calls;
+      expect(triggerCall[0].overrides.sms.content).toBe('Device dev-001 is offline. Primary alert: Temperature spike');
+    });
+
+    it('should handle xnovu_render syntax with database templates', async () => {
+      const { data: notification, error } = await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .insert({
+          name: 'Test xnovu_render',
+          payload: {
+            userName: 'Admin User',
+            year: 2024,
+            company: 'XNovu Corp'
+          },
+          recipients: ['test-admin-123'],
+          notification_workflow_id: testWorkflowId,
+          enterprise_id: testEnterpriseId,
+          notification_status: 'PENDING',
+          publish_status: 'PUBLISH',
+          overrides: {
+            email: {
+              subject: 'Welcome {{userName}}',
+              body: 'Hello {{userName}},\n\nWelcome to our system.\n\n{{ xnovu_render("footer_template", { year: 2024, company: "XNovu Corp" }) }}'
+            }
+          }
+        })
+        .select()
+        .single();
+
+      if (error || !notification) {
+        throw new Error(`Failed to create test notification: ${error?.message}`);
+      }
+
+      const result = await triggerNotificationById(notification.id);
+
+      expect(result.success).toBe(true);
+      const [triggerCall] = mockNovuTrigger.mock.calls;
+      expect(triggerCall[0].overrides.email.subject).toBe('Welcome Admin User');
+      expect(triggerCall[0].overrides.email.body).toContain('Hello Admin User');
+      expect(triggerCall[0].overrides.email.body).toContain('Copyright © 2024 XNovu Corp. All rights reserved.');
+    });
+
+    it('should handle missing variables gracefully', async () => {
+      const { data: notification, error } = await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .insert({
+          name: 'Test Missing Variables',
+          payload: {
+            userName: 'Test User'
+            // Missing: buildingName, temperature
+          },
+          recipients: ['test-user-missing'],
+          notification_workflow_id: testWorkflowId,
+          enterprise_id: testEnterpriseId,
+          notification_status: 'PENDING',
+          publish_status: 'PUBLISH',
+          overrides: {
+            email: {
+              subject: 'Alert for {{userName}}',
+              body: 'Building {{buildingName}} temperature is {{temperature}}°C'
+            }
+          }
+        })
+        .select()
+        .single();
+
+      if (error || !notification) {
+        throw new Error(`Failed to create test notification: ${error?.message}`);
+      }
+
+      const result = await triggerNotificationById(notification.id);
+
+      expect(result.success).toBe(true);
+      const [triggerCall] = mockNovuTrigger.mock.calls;
+      expect(triggerCall[0].overrides.email.subject).toBe('Alert for Test User');
+      // Missing variables should remain as placeholders
+      expect(triggerCall[0].overrides.email.body).toBe('Building {{buildingName}} temperature is {{temperature}}°C');
+    });
+
+    it('should handle template rendering errors gracefully', async () => {
+      const { data: notification, error } = await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .insert({
+          name: 'Test Template Error',
+          payload: {
+            userName: 'Error Test'
+          },
+          recipients: ['test-user-error'],
+          notification_workflow_id: testWorkflowId,
+          enterprise_id: testEnterpriseId,
+          notification_status: 'PENDING',
+          publish_status: 'PUBLISH',
+          overrides: {
+            email: {
+              subject: 'Test',
+              // Reference non-existent template
+              body: '{{ xnovu_render("non_existent_template", {}) }}'
+            }
+          }
+        })
+        .select()
+        .single();
+
+      if (error || !notification) {
+        throw new Error(`Failed to create test notification: ${error?.message}`);
+      }
+
+      const result = await triggerNotificationById(notification.id);
+
+      // Should still succeed but with error placeholder
+      expect(result.success).toBe(true);
+      const [triggerCall] = mockNovuTrigger.mock.calls;
+      expect(triggerCall[0].overrides.email.body).toBe('[Template Error: non_existent_template]');
+    });
+
+    it('should handle complex nested templates in overrides', async () => {
+      // Create another template that references the footer
+      const { error: headerError } = await supabase
+        .schema('notify')
+        .from('ent_notification_template')
+        .insert({
+          name: 'Header Template',
+          template_key: 'header_template',
+          channel_type: 'EMAIL',
+          body_template: '=== {{title}} ===\nDate: {{date}}\n',
+          publish_status: 'PUBLISH',
+          deactivated: false,
+          enterprise_id: testEnterpriseId
+        });
+
+      if (headerError) {
+        throw new Error(`Failed to create header template: ${headerError.message}`);
+      }
+
+      const { data: notification, error } = await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .insert({
+          name: 'Test Complex Templates',
+          payload: {
+            title: 'System Report',
+            date: '2024-01-15',
+            content: 'All systems operational',
+            year: 2024,
+            company: 'XNovu Systems'
+          },
+          recipients: ['test-user-complex'],
+          notification_workflow_id: testWorkflowId,
+          enterprise_id: testEnterpriseId,
+          notification_status: 'PENDING',
+          publish_status: 'PUBLISH',
+          overrides: {
+            email: {
+              subject: '{{title}} - {{date}}',
+              body: '{{ xnovu_render("header_template", { title: "System Report", date: "2024-01-15" }) }}\n\n{{content}}\n\n{{ xnovu_render("footer_template", { year: 2024, company: "XNovu Systems" }) }}'
+            }
+          }
+        })
+        .select()
+        .single();
+
+      if (error || !notification) {
+        throw new Error(`Failed to create test notification: ${error?.message}`);
+      }
+
+      const result = await triggerNotificationById(notification.id);
+
+      expect(result.success).toBe(true);
+      const [triggerCall] = mockNovuTrigger.mock.calls;
+      expect(triggerCall[0].overrides.email.subject).toBe('System Report - 2024-01-15');
+      expect(triggerCall[0].overrides.email.body).toContain('=== System Report ===');
+      expect(triggerCall[0].overrides.email.body).toContain('Date: 2024-01-15');
+      expect(triggerCall[0].overrides.email.body).toContain('All systems operational');
+      expect(triggerCall[0].overrides.email.body).toContain('Copyright © 2024 XNovu Systems. All rights reserved.');
+    });
+  });
+
+  describe('Template Rendering Performance', () => {
+    it('should cache rendered templates for performance', async () => {
+      const templateRenderer = getTemplateRenderer();
+      const initialStats = templateRenderer.getCacheStats();
+
+      // Create multiple notifications using the same template
+      const notifications = await Promise.all([1, 2, 3].map(async (i) => {
+        const { data, error } = await supabase
+          .schema('notify')
+          .from('ent_notification')
+          .insert({
+            name: `Test Cache ${i}`,
+            payload: { userName: `User ${i}`, year: 2024, company: 'XNovu' },
+            recipients: [`test-user-cache-${i}`],
+            notification_workflow_id: testWorkflowId,
+            enterprise_id: testEnterpriseId,
+            notification_status: 'PENDING',
+            publish_status: 'PUBLISH',
+            overrides: {
+              email: {
+                body: 'Hi {{userName}}, {{ xnovu_render("footer_template", { year: 2024, company: "XNovu" }) }}'
+              }
+            }
+          })
+          .select()
+          .single();
+
+        if (error || !data) throw new Error(`Failed to create notification ${i}`);
+        return data;
+      }));
+
+      // Trigger all notifications
+      for (const notification of notifications) {
+        await triggerNotificationById(notification.id);
+      }
+
+      const finalStats = templateRenderer.getCacheStats();
+      
+      // Should have cached the footer_template
+      expect(finalStats.totalCached).toBeGreaterThan(initialStats.totalCached);
+      expect(finalStats.validCached).toBeGreaterThan(0);
+    });
+  });
+
+  describe('Multi-Channel Template Rendering', () => {
+    it('should render templates across different channels', async () => {
+      // Create channel-specific templates
+      await Promise.all([
+        supabase.schema('notify').from('ent_notification_template').insert({
+          name: 'SMS Template',
+          template_key: 'sms_alert',
+          channel_type: 'SMS',
+          body_template: 'Alert: {{message}} at {{location}}',
+          publish_status: 'PUBLISH',
+          deactivated: false,
+          enterprise_id: testEnterpriseId
+        }),
+        supabase.schema('notify').from('ent_notification_template').insert({
+          name: 'Push Template',
+          template_key: 'push_alert',
+          channel_type: 'PUSH',
+          body_template: '🔔 {{title}}: {{description}}',
+          publish_status: 'PUBLISH',
+          deactivated: false,
+          enterprise_id: testEnterpriseId
+        })
+      ]);
+
+      const { data: notification, error } = await supabase
+        .schema('notify')
+        .from('ent_notification')
+        .insert({
+          name: 'Multi-Channel Test',
+          payload: {
+            message: 'Temperature exceeded',
+            location: 'Server Room A',
+            title: 'Critical Alert',
+            description: 'Immediate action required',
+            userName: 'Operations Team'
+          },
+          recipients: ['test-ops-team'],
+          notification_workflow_id: testWorkflowId,
+          enterprise_id: testEnterpriseId,
+          notification_status: 'PENDING',
+          publish_status: 'PUBLISH',
+          overrides: {
+            email: {
+              subject: 'Alert: {{title}}',
+              body: 'Dear {{userName}},\n\n{{message}} at {{location}}.\n\n{{ xnovu_render("footer_template", { year: 2024, company: "XNovu" }) }}'
+            },
+            sms: {
+              content: '{{ xnovu_render("sms_alert", { message: "Temperature exceeded", location: "Server Room A" }) }}'
+            },
+            push: {
+              content: '{{ xnovu_render("push_alert", { title: "Critical Alert", description: "Immediate action required" }) }}'
+            }
+          }
+        })
+        .select()
+        .single();
+
+      if (error || !notification) {
+        throw new Error(`Failed to create multi-channel notification: ${error?.message}`);
+      }
+
+      const result = await triggerNotificationById(notification.id);
+
+      expect(result.success).toBe(true);
+      const [triggerCall] = mockNovuTrigger.mock.calls;
+      
+      // Verify all channels were rendered correctly
+      expect(triggerCall[0].overrides.email.subject).toBe('Alert: Critical Alert');
+      expect(triggerCall[0].overrides.email.body).toContain('Dear Operations Team');
+      expect(triggerCall[0].overrides.email.body).toContain('Temperature exceeded at Server Room A');
+      expect(triggerCall[0].overrides.email.body).toContain('Copyright © 2024 XNovu. All rights reserved.');
+      expect(triggerCall[0].overrides.sms.content).toBe('Alert: Temperature exceeded at Server Room A');
+      expect(triggerCall[0].overrides.push.content).toBe('🔔 Critical Alert: Immediate action required');
+    });
+  });
+});

--- a/__tests__/unit/NotificationTriggerTemplates.test.ts
+++ b/__tests__/unit/NotificationTriggerTemplates.test.ts
@@ -1,0 +1,343 @@
+import { renderTemplatesInOverrides } from '@/lib/notifications/trigger';
+import { getTemplateRenderer } from '@/app/services/template/TemplateRenderer';
+
+// Access the private function through module exports
+const triggerModule = require('@/lib/notifications/trigger');
+
+// Mock the template renderer
+jest.mock('@/app/services/template/TemplateRenderer');
+
+describe('Notification Trigger Template Rendering', () => {
+  let mockTemplateRenderer: jest.Mocked<ReturnType<typeof getTemplateRenderer>>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Create mock template renderer
+    mockTemplateRenderer = {
+      render: jest.fn(),
+      renderTemplate: jest.fn(),
+      validateTemplate: jest.fn(),
+      clearCache: jest.fn(),
+      clearExpiredCache: jest.fn(),
+      getCacheStats: jest.fn()
+    } as any;
+
+    (getTemplateRenderer as jest.Mock).mockReturnValue(mockTemplateRenderer);
+  });
+
+  describe('renderTemplatesInOverrides', () => {
+    const testEnterpriseId = 'test-enterprise-123';
+    const testPayload = {
+      userName: 'John Doe',
+      buildingName: 'Tower A',
+      temperature: 25.5,
+      alert: {
+        level: 'HIGH',
+        message: 'Temperature exceeded threshold'
+      }
+    };
+
+    it('should render simple template strings in overrides', async () => {
+      mockTemplateRenderer.render.mockImplementation(async (template, context) => {
+        // Simple mock implementation that replaces variables
+        let result = template;
+        Object.entries(context.variables).forEach(([key, value]) => {
+          result = result.replace(new RegExp(`{{\\s*${key}\\s*}}`, 'g'), String(value));
+        });
+        return result;
+      });
+
+      const overrides = {
+        email: {
+          subject: 'Alert for {{userName}}',
+          body: 'Building {{buildingName}} temperature is {{temperature}}°C'
+        }
+      };
+
+      const result = await triggerModule.renderTemplatesInOverrides(
+        overrides,
+        testPayload,
+        testEnterpriseId
+      );
+
+      expect(result).toEqual({
+        email: {
+          subject: 'Alert for John Doe',
+          body: 'Building Tower A temperature is 25.5°C'
+        }
+      });
+
+      expect(mockTemplateRenderer.render).toHaveBeenCalledTimes(2);
+      expect(mockTemplateRenderer.render).toHaveBeenCalledWith(
+        'Alert for {{userName}}',
+        { enterpriseId: testEnterpriseId, variables: testPayload }
+      );
+    });
+
+    it('should handle nested objects in overrides', async () => {
+      mockTemplateRenderer.render.mockImplementation(async (template) => {
+        return template.replace('{{alert.level}}', 'HIGH');
+      });
+
+      const overrides = {
+        channels: {
+          email: {
+            subject: 'Level {{alert.level}} Alert',
+            content: {
+              header: 'Alert Level: {{alert.level}}',
+              body: 'Please respond immediately'
+            }
+          },
+          sms: {
+            message: '{{alert.level}} priority alert'
+          }
+        }
+      };
+
+      const result = await triggerModule.renderTemplatesInOverrides(
+        overrides,
+        testPayload,
+        testEnterpriseId
+      );
+
+      expect(result.channels.email.subject).toBe('Level HIGH Alert');
+      expect(result.channels.email.content.header).toBe('Alert Level: HIGH');
+      expect(result.channels.sms.message).toBe('HIGH priority alert');
+    });
+
+    it('should handle arrays in overrides', async () => {
+      mockTemplateRenderer.render.mockImplementation(async (template) => {
+        return template.replace('{{userName}}', 'John Doe');
+      });
+
+      const overrides = {
+        notifications: [
+          { message: 'Hello {{userName}}' },
+          { message: 'Goodbye {{userName}}' }
+        ],
+        recipients: ['user1', 'user2'] // Non-string array should remain unchanged
+      };
+
+      const result = await triggerModule.renderTemplatesInOverrides(
+        overrides,
+        testPayload,
+        testEnterpriseId
+      );
+
+      expect(result.notifications[0].message).toBe('Hello John Doe');
+      expect(result.notifications[1].message).toBe('Goodbye John Doe');
+      expect(result.recipients).toEqual(['user1', 'user2']);
+    });
+
+    it('should preserve non-string values', async () => {
+      const overrides = {
+        settings: {
+          enabled: true,
+          count: 42,
+          threshold: 25.5,
+          metadata: null,
+          template: 'User: {{userName}}'
+        }
+      };
+
+      mockTemplateRenderer.render.mockImplementation(async (template) => {
+        return template.replace('{{userName}}', 'John Doe');
+      });
+
+      const result = await triggerModule.renderTemplatesInOverrides(
+        overrides,
+        testPayload,
+        testEnterpriseId
+      );
+
+      expect(result.settings.enabled).toBe(true);
+      expect(result.settings.count).toBe(42);
+      expect(result.settings.threshold).toBe(25.5);
+      expect(result.settings.metadata).toBeNull();
+      expect(result.settings.template).toBe('User: John Doe');
+    });
+
+    it('should skip strings without template syntax', async () => {
+      const overrides = {
+        plain: {
+          message: 'This is a plain message',
+          alert: 'No templates here!'
+        },
+        templated: {
+          message: 'Hello {{userName}}'
+        }
+      };
+
+      mockTemplateRenderer.render.mockImplementation(async (template) => {
+        return template.replace('{{userName}}', 'John Doe');
+      });
+
+      const result = await triggerModule.renderTemplatesInOverrides(
+        overrides,
+        testPayload,
+        testEnterpriseId
+      );
+
+      // render should only be called for strings with template syntax
+      expect(mockTemplateRenderer.render).toHaveBeenCalledTimes(1);
+      expect(mockTemplateRenderer.render).toHaveBeenCalledWith(
+        'Hello {{userName}}',
+        expect.any(Object)
+      );
+
+      expect(result.plain.message).toBe('This is a plain message');
+      expect(result.plain.alert).toBe('No templates here!');
+      expect(result.templated.message).toBe('Hello John Doe');
+    });
+
+    it('should handle template rendering errors gracefully', async () => {
+      mockTemplateRenderer.render.mockRejectedValue(new Error('Template error'));
+
+      const overrides = {
+        email: {
+          subject: 'Alert',
+          body: 'Error template: {{unknownVar}}'
+        }
+      };
+
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+      const result = await triggerModule.renderTemplatesInOverrides(
+        overrides,
+        testPayload,
+        testEnterpriseId
+      );
+
+      // Should return original value on error
+      expect(result.email.body).toBe('Error template: {{unknownVar}}');
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[WARN] Template rendering failed, using original value',
+        expect.stringContaining('Template error')
+      );
+
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('should handle empty overrides', async () => {
+      const result = await triggerModule.renderTemplatesInOverrides(
+        {},
+        testPayload,
+        testEnterpriseId
+      );
+
+      expect(result).toEqual({});
+      expect(mockTemplateRenderer.render).not.toHaveBeenCalled();
+    });
+
+    it('should handle null/undefined overrides', async () => {
+      const nullResult = await triggerModule.renderTemplatesInOverrides(
+        null,
+        testPayload,
+        testEnterpriseId
+      );
+      expect(nullResult).toBeNull();
+
+      const undefinedResult = await triggerModule.renderTemplatesInOverrides(
+        undefined,
+        testPayload,
+        testEnterpriseId
+      );
+      expect(undefinedResult).toBeUndefined();
+    });
+
+    it('should deep clone overrides to avoid mutation', async () => {
+      const originalOverrides = {
+        email: {
+          subject: 'Test {{userName}}',
+          metadata: { important: true }
+        }
+      };
+
+      mockTemplateRenderer.render.mockImplementation(async (template) => {
+        return template.replace('{{userName}}', 'John Doe');
+      });
+
+      const result = await triggerModule.renderTemplatesInOverrides(
+        originalOverrides,
+        testPayload,
+        testEnterpriseId
+      );
+
+      // Result should be different object
+      expect(result).not.toBe(originalOverrides);
+      expect(result.email).not.toBe(originalOverrides.email);
+
+      // Original should be unchanged
+      expect(originalOverrides.email.subject).toBe('Test {{userName}}');
+      
+      // Result should have rendered template
+      expect(result.email.subject).toBe('Test John Doe');
+    });
+
+    it('should handle complex nested template rendering', async () => {
+      mockTemplateRenderer.render
+        .mockResolvedValueOnce('Welcome John Doe')
+        .mockResolvedValueOnce('Building: Tower A, Temp: 25.5°C')
+        .mockResolvedValueOnce('HIGH: Temperature exceeded threshold');
+
+      const overrides = {
+        notification: {
+          header: {
+            title: 'Welcome {{userName}}',
+            subtitle: 'Building: {{buildingName}}, Temp: {{temperature}}°C'
+          },
+          body: {
+            sections: [
+              {
+                type: 'alert',
+                content: '{{alert.level}}: {{alert.message}}'
+              }
+            ]
+          },
+          metadata: {
+            processedAt: new Date('2024-01-15'),
+            version: 2
+          }
+        }
+      };
+
+      const result = await triggerModule.renderTemplatesInOverrides(
+        overrides,
+        testPayload,
+        testEnterpriseId
+      );
+
+      expect(result.notification.header.title).toBe('Welcome John Doe');
+      expect(result.notification.header.subtitle).toBe('Building: Tower A, Temp: 25.5°C');
+      expect(result.notification.body.sections[0].content).toBe('HIGH: Temperature exceeded threshold');
+      // Date gets serialized to string in JSON.parse/stringify
+      expect(result.notification.metadata.processedAt).toBe('2024-01-15T00:00:00.000Z');
+      expect(result.notification.metadata.version).toBe(2);
+    });
+  });
+
+  describe('Template detection logic', () => {
+    it('should correctly identify strings with template syntax', () => {
+      const testCases = [
+        { input: 'Hello {{name}}', shouldHaveTemplate: true },
+        { input: 'Multiple {{var1}} and {{var2}}', shouldHaveTemplate: true },
+        { input: '{{ spaced }}', shouldHaveTemplate: true },
+        { input: 'Nested {{user.name}}', shouldHaveTemplate: true },
+        { input: 'Array {{items[0]}}', shouldHaveTemplate: true },
+        { input: 'Plain text', shouldHaveTemplate: false },
+        { input: 'Single { bracket', shouldHaveTemplate: false },
+        { input: 'Single } bracket', shouldHaveTemplate: false },
+        { input: 'Not {{complete', shouldHaveTemplate: false },
+        { input: 'Not complete}}', shouldHaveTemplate: false },
+        { input: '{}', shouldHaveTemplate: false },
+        { input: '', shouldHaveTemplate: false }
+      ];
+
+      testCases.forEach(({ input, shouldHaveTemplate }) => {
+        const hasTemplate = input.includes('{{') && input.includes('}}');
+        expect(hasTemplate).toBe(shouldHaveTemplate);
+      });
+    });
+  });
+});

--- a/lib/notifications/trigger.ts
+++ b/lib/notifications/trigger.ts
@@ -8,6 +8,7 @@
 import { createClient } from '@supabase/supabase-js';
 import { Novu } from '@novu/api';
 import type { Database } from '@/lib/supabase/database.types';
+import { getTemplateRenderer } from '@/app/services/template/TemplateRenderer';
 
 type NotificationRow = Database['notify']['Tables']['ent_notification']['Row'];
 type NotificationWorkflowRow = Database['notify']['Tables']['ent_notification_workflow']['Row'];
@@ -126,7 +127,8 @@ export async function triggerNotificationById(
       notification.recipients,
       workflow.workflow_key,
       notification.payload,
-      notification.overrides
+      notification.overrides,
+      notification.enterprise_id // Pass enterprise_id for template rendering
     );
 
     const successCount = recipientResults.filter(r => r.success).length;
@@ -333,15 +335,31 @@ async function triggerForRecipients(
   recipients: string[],
   workflowId: string,
   payload: any,
-  overrides?: any
+  overrides?: any,
+  enterpriseId?: string
 ): Promise<RecipientResult[]> {
+  // Check if we need to render templates
+  let processedOverrides = overrides || {};
+  
+  if (enterpriseId && overrides) {
+    try {
+      processedOverrides = await renderTemplatesInOverrides(overrides, payload, enterpriseId);
+    } catch (error) {
+      logger.error('Failed to render templates in overrides', { 
+        error: error instanceof Error ? error.message : 'Unknown error',
+        enterpriseId 
+      });
+      // Continue with original overrides if template rendering fails
+    }
+  }
+
   const novuPromises = recipients.map(async (recipientId) => {
     try {
       const result = await novu.trigger({
         workflowId,
         to: recipientId,
         payload: payload as any,
-        overrides: overrides as any || {}
+        overrides: processedOverrides as any
       });
       
       return { 
@@ -363,5 +381,61 @@ async function triggerForRecipients(
   });
 
   return Promise.all(novuPromises);
+}
+
+/**
+ * Render templates found in notification overrides
+ * Detects template tags and processes them with TemplateRenderer
+ */
+export async function renderTemplatesInOverrides(
+  overrides: any,
+  payload: any,
+  enterpriseId: string
+): Promise<any> {
+  // Handle null/undefined overrides
+  if (!overrides) {
+    return overrides;
+  }
+  
+  const templateRenderer = getTemplateRenderer();
+  const processedOverrides = JSON.parse(JSON.stringify(overrides)); // Deep clone
+  
+  // Function to recursively process template strings
+  const processTemplateString = async (value: any): Promise<any> => {
+    if (typeof value === 'string') {
+      // Check if the string contains template syntax
+      if (value.includes('{{') && value.includes('}}')) {
+        try {
+          // Render the template with payload as variables
+          const rendered = await templateRenderer.render(value, {
+            enterpriseId,
+            variables: payload
+          });
+          return rendered;
+        } catch (error) {
+          logger.warn('Template rendering failed, using original value', {
+            error: error instanceof Error ? error.message : 'Unknown error',
+            template: value.substring(0, 100) // Log first 100 chars
+          });
+          return value;
+        }
+      }
+    } else if (Array.isArray(value)) {
+      // Process arrays recursively
+      return Promise.all(value.map(item => processTemplateString(item)));
+    } else if (value && typeof value === 'object') {
+      // Process objects recursively
+      const processed: any = {};
+      for (const [key, val] of Object.entries(value)) {
+        processed[key] = await processTemplateString(val);
+      }
+      return processed;
+    }
+    
+    return value;
+  };
+  
+  // Process the entire overrides object
+  return processTemplateString(processedOverrides);
 }
 


### PR DESCRIPTION
## Summary
- Adds runtime template rendering to notification overrides when triggering notifications
- Automatically detects and processes template syntax in notification content
- Maintains backward compatibility - notifications without templates work as before

## Features
- **Variable Interpolation**: Support for `{{variable}}`, `{{nested.property}}`, and `{{array[0]}}` syntax
- **Nested Templates**: Support for `{{ xnovu_render('template_key', { variables }) }}` to include reusable templates
- **Multi-Channel Support**: Templates work across all notification channels (EMAIL, SMS, IN_APP, PUSH)
- **Error Resilience**: Graceful fallback to original content if template rendering fails
- **Enterprise Isolation**: Templates are rendered with proper enterprise context for multi-tenancy

## Test Plan
- [x] Unit tests for template rendering in notification overrides
- [x] Integration tests with real Supabase database (when credentials available)
- [x] Test simple variable interpolation
- [x] Test nested object and array access
- [x] Test xnovu_render syntax with database templates
- [x] Test error handling and fallback behavior
- [x] Test multi-channel template rendering
- [x] Test performance with template caching

## Implementation Details
The template rendering is integrated into the `triggerNotificationById` flow:
1. When a notification is triggered, the system checks if overrides contain template syntax
2. If templates are detected, they are rendered using the TemplateRenderer with the notification payload as variables
3. The rendered content is then passed to Novu for delivery
4. If rendering fails, the original content is used as fallback

This allows dynamic content generation at runtime while maintaining the flexibility of the template system.

🤖 Generated with [Claude Code](https://claude.ai/code)