### PR TITLE
fix: resolve DynamicWorkflowFactory test side effects and race conditions

### DIFF
--- a/__tests__/integration/DynamicWorkflowFactory.integration.test.ts
+++ b/__tests__/integration/DynamicWorkflowFactory.integration.test.ts
@@ -195,7 +195,8 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
       DynamicWorkflowFactory.createDynamicWorkflow(config, testEnterpriseId);
 
       // Get the step function that was passed to workflow()
-      const stepFunction = mockWorkflow.mock.calls[0][1];
+      // Get the most recent workflow call (this test's workflow)
+      const stepFunction = mockWorkflow.mock.calls[mockWorkflow.mock.calls.length - 1][1];
 
       // Mock step object that actually calls the step function
       const mockStep = {
@@ -257,7 +258,8 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
       DynamicWorkflowFactory.createDynamicWorkflow(config, testEnterpriseId);
 
       // Get the step function
-      const stepFunction = mockWorkflow.mock.calls[0][1];
+      // Get the most recent workflow call (this test's workflow)
+      const stepFunction = mockWorkflow.mock.calls[mockWorkflow.mock.calls.length - 1][1];
 
       // Mock step object that executes the step function
       const mockStep = {
@@ -304,7 +306,8 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
 
       // Create workflow
       DynamicWorkflowFactory.createDynamicWorkflow(config, testEnterpriseId);
-      const stepFunction = mockWorkflow.mock.calls[0][1];
+      // Get the most recent workflow call (this test's workflow)
+      const stepFunction = mockWorkflow.mock.calls[mockWorkflow.mock.calls.length - 1][1];
 
       // Mock successful step execution
       const mockStep = {
@@ -372,7 +375,8 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
         .mockRejectedValueOnce(new Error('SMS template error')); // SMS
 
       DynamicWorkflowFactory.createDynamicWorkflow(config, testEnterpriseId);
-      const stepFunction = mockWorkflow.mock.calls[0][1];
+      // Get the most recent workflow call (this test's workflow)
+      const stepFunction = mockWorkflow.mock.calls[mockWorkflow.mock.calls.length - 1][1];
 
       const mockStep = {
         email: jest.fn().mockImplementation(async (stepId, stepFunc) => {
@@ -393,6 +397,9 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
           data: { message: 'Test message' }
         }
       })).rejects.toThrow('SMS template error');
+
+      // Small delay to ensure database update completes
+      await new Promise(resolve => setTimeout(resolve, 100));
 
       // Verify notification was marked as failed
       const updatedNotification = await notificationService.getNotification(testNotification.id, testEnterpriseId);
@@ -422,7 +429,8 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
         .mockResolvedValueOnce({ subject: 'Push Title', body: 'Push Body' });
 
       DynamicWorkflowFactory.createDynamicWorkflow(config, testEnterpriseId);
-      const stepFunction = mockWorkflow.mock.calls[0][1];
+      // Get the most recent workflow call (this test's workflow)
+      const stepFunction = mockWorkflow.mock.calls[mockWorkflow.mock.calls.length - 1][1];
 
       const mockStep = {
         email: jest.fn().mockImplementation(async (stepId, stepFunc) => await stepFunc()),


### PR DESCRIPTION
## Summary
- Fixes intermittent failures in DynamicWorkflowFactory integration test when run as part of full test suite
- Resolves race conditions and side effects between concurrent test execution

## Changes Made
- **Fixed mock call index assumption**: Changed from `mockWorkflow.mock.calls[0][1]` to use the most recent workflow call instead of assuming the first call
- **Added timing buffer**: Added 100ms delay after workflow execution to ensure database status updates complete before assertions
- **Improved test isolation**: Prevents race conditions when multiple tests create workflows concurrently

## Test Results
The test now passes consistently both:
- ✅ When run in isolation: `pnpm test __tests__/integration/DynamicWorkflowFactory.integration.test.ts`
- ✅ When run as part of the full test suite: `pnpm test`

## Problem Solved
Previously, the test would:
- ✅ Pass when run individually
- ❌ Fail when run with full test suite with error: `Expected: "FAILED", Received: "PROCESSING"`

This was caused by other tests affecting the mock call indices and timing issues with database updates.

🤖 Generated with [Claude Code](https://claude.ai/code)