### PR TITLE
fix: resolve test conflicts in parallel execution

### DIFF
--- a/__tests__/integration/DynamicWorkflowFactory.integration.test.ts
+++ b/__tests__/integration/DynamicWorkflowFactory.integration.test.ts
@@ -179,7 +179,7 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
   describe('Workflow Execution with Real Database Status Updates', () => {
     it('should update notification status through complete workflow execution', async () => {
       const config: WorkflowConfig = {
-        workflow_key: 'status-tracking-workflow-integration',
+        workflow_key: `status-tracking-workflow-integration-${Date.now()}-${Math.random()}`,
         workflow_type: 'DYNAMIC',
         channels: ['EMAIL'],
         emailTemplateId: 123
@@ -187,8 +187,10 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
 
       // Create a real notification in the database
       const testNotification = await createTestNotification({
-        name: 'Status Tracking Integration Test',
-        notification_status: 'PENDING'
+        name: `Status Tracking Integration Test ${Date.now()}-${Math.random()}`,
+        notification_status: 'PENDING',
+        deactivated: true, // Prevent polling service from interfering
+        scheduled_for: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() // Schedule for tomorrow
       });
 
       // Create workflow
@@ -237,7 +239,7 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
 
     it('should handle workflow execution errors and update status to FAILED in database', async () => {
       const config: WorkflowConfig = {
-        workflow_key: 'error-workflow-integration',
+        workflow_key: `error-workflow-integration-${Date.now()}-${Math.random()}`,
         workflow_type: 'DYNAMIC',
         channels: ['EMAIL'],
         emailTemplateId: 123
@@ -245,8 +247,10 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
 
       // Create a real notification in the database
       const testNotification = await createTestNotification({
-        name: 'Error Test Notification Integration',
-        notification_status: 'PENDING'
+        name: `Error Test Notification Integration ${Date.now()}-${Math.random()}`,
+        notification_status: 'PENDING',
+        deactivated: true, // Prevent polling service from picking this up
+        scheduled_for: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() // Schedule for tomorrow
       });
 
       // Mock template rendering to throw error
@@ -286,7 +290,7 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
 
     it('should update notification status through multi-channel workflow execution', async () => {
       const config: WorkflowConfig = {
-        workflow_key: 'multi-channel-integration-workflow',
+        workflow_key: `multi-channel-integration-workflow-${Date.now()}-${Math.random()}`,
         workflow_type: 'DYNAMIC',
         channels: ['EMAIL', 'IN_APP'],
         emailTemplateId: 123,
@@ -295,13 +299,17 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
 
       // Create real notifications in database
       const emailNotification = await createTestNotification({
-        name: 'Email Integration Test',
-        notification_status: 'PENDING'
+        name: `Email Integration Test ${Date.now()}-${Math.random()}`,
+        notification_status: 'PENDING',
+        deactivated: true, // Prevent polling service from interfering
+        scheduled_for: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() // Schedule for tomorrow
       });
 
       const inAppNotification = await createTestNotification({
-        name: 'In-App Integration Test',
-        notification_status: 'PENDING'
+        name: `In-App Integration Test ${Date.now()}-${Math.random()}`, 
+        notification_status: 'PENDING',
+        deactivated: true, // Prevent polling service from interfering
+        scheduled_for: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() // Schedule for tomorrow
       });
 
       // Create workflow
@@ -421,7 +429,7 @@ describe('DynamicWorkflowFactory Integration Tests with Real Services', () => {
   describe('Workflow Factory with Template Rendering Integration', () => {
     it('should integrate with template rendering service for all channel types', async () => {
       const config: WorkflowConfig = {
-        workflow_key: 'template-integration-workflow',
+        workflow_key: `template-integration-workflow-${Date.now()}-${Math.random()}`,
         workflow_type: 'DYNAMIC',
         channels: ['EMAIL', 'IN_APP', 'SMS', 'PUSH'],
         emailTemplateId: 123,

--- a/__tests__/unit/NotificationService.test.ts
+++ b/__tests__/unit/NotificationService.test.ts
@@ -194,8 +194,10 @@ describe('NotificationService Unit Tests', () => {
     it('should cancel notification by setting status to RETRACTED', async () => {
       // Create a fresh notification for this test to avoid interference
       const insertData = createTestNotificationInsert({
-        name: `Notification for Cancellation ${Date.now()}`,
-        publish_status: 'DRAFT' // Set to DRAFT to avoid processing by polling systems
+        name: `Notification for Cancellation ${Date.now()}-${Math.random()}`,
+        publish_status: 'DRAFT', // Set to DRAFT to avoid processing by polling systems
+        deactivated: true, // Ensure notification won't be picked up by polling service
+        scheduled_for: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString() // Schedule for tomorrow to prevent immediate processing
       });
       const notificationToCancel = await service.createNotification(insertData);
       testNotificationIds.push(notificationToCancel.id);
@@ -203,6 +205,7 @@ describe('NotificationService Unit Tests', () => {
       // Verify the notification exists and is in expected state
       const beforeCancel = await service.getNotification(notificationToCancel.id, testEnterpriseId);
       expect(beforeCancel).toBeDefined();
+      expect(beforeCancel!.notification_status).toBe('PENDING');
       
       await service.cancelNotification(notificationToCancel.id, testEnterpriseId);
 


### PR DESCRIPTION
## Summary
- Fixed race condition where polling service would pick up test notifications
- Added `deactivated` flag and future `scheduled_for` timestamp to prevent processing
- Ensured unique workflow keys and notification names using timestamps

## Test plan
- [x] Run NotificationService.test.ts - passes
- [x] Run DynamicWorkflowFactory.integration.test.ts - passes
- [ ] Run tests in parallel to verify no conflicts

## Details
The tests were failing because notifications created with `PENDING` status were being picked up by the polling service and changed to `PROCESSING` before the tests could verify their expected state changes.

This PR fixes the issue by:
1. Setting `deactivated: true` on test notifications
2. Setting `scheduled_for` to a future date (24 hours ahead)
3. Adding unique timestamps to all test data to prevent conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)