### PR TITLE
fix: add TLS support and improve UX for Temporal namespace cleanup script

### DIFF
--- a/scripts/cleanup-temporal-namespaces.sh
+++ b/scripts/cleanup-temporal-namespaces.sh
@@ -30,7 +30,7 @@ echo ""
 
 # Get all namespaces with the specified prefix
 echo "Searching for namespaces with prefix '$NAMESPACE_PREFIX'..."
-namespaces=$(temporal operator namespace list --address "$TEMPORAL_ADDRESS" 2>&1 | \
+namespaces=$(temporal operator namespace list --address "$TEMPORAL_ADDRESS" --tls 2>&1 | \
   grep -A1 "NamespaceInfo.Name.*${NAMESPACE_PREFIX}" | \
   grep "NamespaceInfo.Name" | \
   awk '{print $2}')
@@ -48,8 +48,8 @@ echo "$namespaces" | sed 's/^/  - /'
 echo ""
 
 # Confirm deletion
-read -p "Are you sure you want to delete these $total namespace(s)? (yes/no): " confirm
-if [ "$confirm" != "yes" ]; then
+read -p "Are you sure you want to delete these $total namespace(s)? (yes/y/no): " confirm
+if [ "$confirm" != "yes" ] && [ "$confirm" != "y" ]; then
     echo "Deletion cancelled"
     exit 0
 fi
@@ -72,6 +72,7 @@ for namespace in $namespaces; do
     if temporal operator namespace delete \
         --namespace "$namespace" \
         --address "$TEMPORAL_ADDRESS" \
+        --tls \
         --yes 2>&1 | grep -q "has been deleted"; then
         echo "  ✓ Successfully deleted $namespace"
         success=$((success + 1))
@@ -91,7 +92,7 @@ echo "Failed to delete: $failed"
 echo ""
 
 # Final verification
-remaining=$(temporal operator namespace list --address "$TEMPORAL_ADDRESS" 2>&1 | \
+remaining=$(temporal operator namespace list --address "$TEMPORAL_ADDRESS" --tls 2>&1 | \
   grep -c "NamespaceInfo.Name.*${NAMESPACE_PREFIX}")
 echo "Remaining namespaces with prefix '$NAMESPACE_PREFIX': $remaining"
 


### PR DESCRIPTION
## Summary
- Fixed Temporal namespace cleanup script to work with cloud/remote Temporal servers
- Added --tls flag to all temporal CLI commands for secure connections
- Improved user experience by accepting both 'y' and 'yes' for confirmation prompts

## Test plan
- [x] Verified script can now find namespaces with test-ns prefix on remote Temporal server
- [x] Confirmed TLS connection works with temporal-grpc.hooloovoo.io:443
- [x] Tested confirmation prompt accepts both 'y' and 'yes' responses

🤖 Generated with [Claude Code](https://claude.ai/code)